### PR TITLE
Send nvic interrupt when irq triggered

### DIFF
--- a/hw/avatar/configurable_machine.c
+++ b/hw/avatar/configurable_machine.c
@@ -546,6 +546,23 @@ static THISCPU *create_cpu(MachineState * ms, QDict *conf)
 
         cpuu = ARM_CPU(first_cpu);
 
+    // same with armv8m cpus
+    } else if (!strcmp(cpu_type, "cortex-m33")) {
+
+        if (qdict_haskey(conf, "num_irq")) {
+            num_irq = qdict_get_int(conf, "num_irq");
+            g_assert(num_irq);
+        }
+
+        dstate = qdev_new("armv7m");
+        qdev_prop_set_uint32(dstate, "num-irq", num_irq);
+        qdev_prop_set_string(dstate, "cpu-type", ARM_CPU_TYPE_NAME("cortex-m33"));
+        object_property_set_link(OBJECT(dstate), "memory",
+        OBJECT(get_system_memory()), &error_abort);
+        qdev_realize_and_unref(dstate, sysbus, NULL);
+
+        cpuu = ARM_CPU(first_cpu);
+
     } else {
 #endif  /* ! TARGET_AARCH64 */
         cpu_oc = cpu_class_by_name(TYPE_ARM_CPU, cpu_type);

--- a/hw/avatar/irq_controller.c
+++ b/hw/avatar/irq_controller.c
@@ -165,6 +165,11 @@ static void halucinator_irq_set_irq_setter(Object *obj, Visitor *v,
         return;
     }
 
+    // also send NVIC interrupt
+    ARMCPU *armcpu = ARM_CPU(qemu_get_cpu(0));
+    CPUARMState *env = &armcpu->env;
+    armv7m_nvic_set_pending(env->nvic, irq_num, false);
+
     irq_handler(s, irq_num, 1);
 
 }
@@ -201,6 +206,7 @@ static void halucinator_irq_enable_irq_setter(Object *obj, Visitor *v,
 
     printf("QEMU: Enabling IRQ %li", irq_num);
     s->irq_regs[irq_num] |= IRQ_N_ENABLED;
+    s->status_reg |= GLOBAL_IRQ_ENABLED;
     update_irq(s);
 
 }

--- a/hw/avatar/irq_controller.c
+++ b/hw/avatar/irq_controller.c
@@ -165,10 +165,12 @@ static void halucinator_irq_set_irq_setter(Object *obj, Visitor *v,
         return;
     }
 
+#if defined(TARGET_ARM) || defined(TARGET_AARCH64)
     // also send NVIC interrupt
     ARMCPU *armcpu = ARM_CPU(qemu_get_cpu(0));
     CPUARMState *env = &armcpu->env;
     armv7m_nvic_set_pending(env->nvic, irq_num, false);
+#endif
 
     irq_handler(s, irq_num, 1);
 


### PR DESCRIPTION
Adds detection for NVIC interrupt, which is used on certain ARM systems, when sending IRQ. This allows us to trigger interrupts on ARM systems. Tested this on NUCLEO-F401RE (Arm Cortex-M4).