### PR TITLE
Fix PPC/PPC64 support to configurable machine

### DIFF
--- a/hw/avatar/configurable_machine.c
+++ b/hw/avatar/configurable_machine.c
@@ -616,13 +616,20 @@ static THISCPU *create_cpu(MachineState * ms, QDict *conf)
     // cpuobj = object_new(cpu_type);
     cpuu = POWERPC_CPU(cpu_create(cpu_type));
 
-    /* Don't initialize timebase/decrementer for configurable machine.
-     * The decrementer would fire interrupts that the configurable
-     * machine can't handle (no exception vectors set up).
-     * Firmware that needs timers can set up its own via BP handlers. */
+    /* Initialize timebase so SPR reads (TBL/TBU) return real values.
+     * The decrementer timer will eventually fire, but MSR[EE]=0 prevents
+     * the exception from being delivered to the CPU. */
+    if (cpuu->env.flags & POWERPC_FLAG_RTC_CLK) {
+        /* POWER / PowerPC 601 RTC clock frequency is 7.8125 MHz */
+        cpu_ppc_tb_init(&(cpuu->env), 7812500UL);
+    } else {
+        /* Set time-base frequency to 100 Mhz */
+        cpu_ppc_tb_init(&(cpuu->env), 100UL * 1000UL * 1000UL);
+    }
 
-    /* Fix MSR, hflags, interrupts, and TLB for configurable machine. */
-    cpuu->env.msr &= ~((1ULL << MSR_EP) | (target_ulong)MSR_HVB);
+    /* Fix MSR, hflags, interrupts, and TLB for configurable machine.
+     * Clear MSR[EE] to mask the decrementer interrupt. */
+    cpuu->env.msr &= ~((1ULL << MSR_EP) | (1ULL << MSR_EE) | (target_ulong)MSR_HVB);
     cpuu->env.pending_interrupts = 0;
     CPU(cpuu)->interrupt_request = 0;
     CPU(cpuu)->exception_index = POWERPC_EXCP_NONE;
@@ -740,9 +747,10 @@ static void ppc_cpu_reset_handler(void *opaque)
     /* After CPU reset, fix MSR, hflags, and TLB for configurable machine.
      * Clear MSR[EP] so exception vectors are at 0x00000000 instead of
      * 0xFFF00000 (which likely has no memory mapped).
+     * Clear MSR[EE] to mask the decrementer interrupt.
      * Also clear MSR[HVB] to avoid hypervisor mode issues. */
     printf("Configurable: PPC reset handler - fixing MSR, hflags, interrupts, TLB\n");
-    env->msr &= ~((1ULL << MSR_EP) | (target_ulong)MSR_HVB);
+    env->msr &= ~((1ULL << MSR_EP) | (1ULL << MSR_EE) | (target_ulong)MSR_HVB);
     env->pending_interrupts = 0;
     CPU(cpu)->interrupt_request = 0;
     CPU(cpu)->exception_index = POWERPC_EXCP_NONE;

--- a/hw/avatar/configurable_machine.c
+++ b/hw/avatar/configurable_machine.c
@@ -27,6 +27,7 @@
 #include "qemu/osdep.h"
 #include "qemu/error-report.h"
 #include "sysemu/sysemu.h"
+#include "sysemu/reset.h"
 #include "exec/address-spaces.h"
 #include "exec/hwaddr.h"
 #include "hw/hw.h"
@@ -61,6 +62,7 @@ typedef  MIPSCPU THISCPU;
 #elif defined(TARGET_PPC)
 #include "hw/ppc/ppc.h"
 #include "target/ppc/cpu.h"
+#include "target/ppc/helper_regs.h"
 typedef PowerPCCPU THISCPU;
 
 #elif defined(TARGET_AVR)
@@ -614,12 +616,33 @@ static THISCPU *create_cpu(MachineState * ms, QDict *conf)
     // cpuobj = object_new(cpu_type);
     cpuu = POWERPC_CPU(cpu_create(cpu_type));
 
-    if (cpuu->env.flags & POWERPC_FLAG_RTC_CLK) {
-        /* POWER / PowerPC 601 RTC clock frequency is 7.8125 MHz */
-        cpu_ppc_tb_init(&(cpuu->env), 7812500UL);
-    } else {
-        /* Set time-base frequency to 100 Mhz */
-        cpu_ppc_tb_init(&(cpuu->env), 100UL * 1000UL * 1000UL);
+    /* Don't initialize timebase/decrementer for configurable machine.
+     * The decrementer would fire interrupts that the configurable
+     * machine can't handle (no exception vectors set up).
+     * Firmware that needs timers can set up its own via BP handlers. */
+
+    /* Fix MSR, hflags, interrupts, and TLB for configurable machine. */
+    cpuu->env.msr &= ~((1ULL << MSR_EP) | (target_ulong)MSR_HVB);
+    cpuu->env.pending_interrupts = 0;
+    CPU(cpuu)->interrupt_request = 0;
+    CPU(cpuu)->exception_index = POWERPC_EXCP_NONE;
+    hreg_compute_hflags(&cpuu->env);
+
+    /* BookE CPUs always use TLB. Set up identity-mapped entries. */
+    if (cpuu->env.tlb.tlbm) {
+        ppcmas_tlb_t *tlb;
+        int i;
+        for (i = 0; i < 4; i++) {
+            tlb = booke206_get_tlbm(&cpuu->env, 1, 0, i);
+            if (tlb) {
+                tlb->mas1 = MAS1_VALID | (10 << MAS1_TSIZE_SHIFT);
+                tlb->mas2 = (uint32_t)i * 0x40000000UL;
+                tlb->mas7_3 = (uint32_t)i * 0x40000000UL;
+                tlb->mas7_3 |= MAS3_UR | MAS3_UW | MAS3_UX |
+                               MAS3_SR | MAS3_SW | MAS3_SX;
+            }
+        }
+        cpuu->env.tlb_dirty = true;
     }
 #endif
 
@@ -708,6 +731,42 @@ static void map_irqs(QDict *dev_dict,  QDict * periphs)
 }
 
 
+#if defined(TARGET_PPC)
+static void ppc_cpu_reset_handler(void *opaque)
+{
+    PowerPCCPU *cpu = opaque;
+    CPUPPCState *env = &cpu->env;
+
+    /* After CPU reset, fix MSR, hflags, and TLB for configurable machine.
+     * Clear MSR[EP] so exception vectors are at 0x00000000 instead of
+     * 0xFFF00000 (which likely has no memory mapped).
+     * Also clear MSR[HVB] to avoid hypervisor mode issues. */
+    printf("Configurable: PPC reset handler - fixing MSR, hflags, interrupts, TLB\n");
+    env->msr &= ~((1ULL << MSR_EP) | (target_ulong)MSR_HVB);
+    env->pending_interrupts = 0;
+    CPU(cpu)->interrupt_request = 0;
+    CPU(cpu)->exception_index = POWERPC_EXCP_NONE;
+    hreg_compute_hflags(env);
+
+    if (env->tlb.tlbm) {
+        ppcmas_tlb_t *tlb;
+        int i;
+        for (i = 0; i < 4; i++) {
+            tlb = booke206_get_tlbm(env, 1, 0, i);
+            if (tlb) {
+                tlb->mas1 = MAS1_VALID | (10 << MAS1_TSIZE_SHIFT);
+                tlb->mas2 = (uint32_t)i * 0x40000000UL;
+                tlb->mas7_3 = (uint32_t)i * 0x40000000UL;
+                tlb->mas7_3 |= MAS3_UR | MAS3_UW | MAS3_UX |
+                               MAS3_SR | MAS3_SW | MAS3_SX;
+            }
+        }
+        env->tlb_dirty = true;
+        printf("Configurable: PPC TLB entries set (4 x 1GB)\n");
+    }
+}
+#endif
+
 static void board_init(MachineState * ms)
 {
     THISCPU *cpuu;
@@ -727,6 +786,11 @@ static void board_init(MachineState * ms)
 
     cpuu = create_cpu(ms, conf);
     avatar_cm_set_entry_point(conf, cpuu);
+
+#if defined(TARGET_PPC)
+    /* Register reset handler to fix hflags after CPU reset */
+    qemu_register_reset(ppc_cpu_reset_handler, cpuu);
+#endif
 
     peripherals = qdict_new();
     qdict_put_obj(peripherals, "cpu", (QObject *)cpuu);

--- a/hw/avatar/meson.build
+++ b/hw/avatar/meson.build
@@ -1,42 +1,50 @@
-specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_ARM'], if_true: files(
-  'configurable_machine.c',
-  'avatar_posix.c',
-  'remote_memory.c',
-  'arm_helper.c',
-  'irq_controller.c'
-))
-specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_AARCH64'], if_true: files(
-  'configurable_machine.c',
-  'avatar_posix.c',
-  'remote_memory.c',
-  'arm_helper.c',
-  'irq_controller.c'
-))
-specific_ss.add(when: ['CONFIG_AVATAR', 'CONFIG_ARM_V7M'], if_true: files(
-  'interrupts.c'
-))
+if have_avatar
+  specific_ss.add(when: 'TARGET_ARM', if_true: files(
+    'configurable_machine.c',
+    'avatar_posix.c',
+    'remote_memory.c',
+    'arm_helper.c',
+    'irq_controller.c'
+  ))
+  specific_ss.add(when: 'TARGET_AARCH64', if_true: files(
+    'configurable_machine.c',
+    'avatar_posix.c',
+    'remote_memory.c',
+    'arm_helper.c',
+    'irq_controller.c'
+  ))
+  specific_ss.add(when: ['CONFIG_ARM_V7M'], if_true: files(
+    'interrupts.c'
+  ))
 
-specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_MIPS'], if_true: files(
-  'configurable_machine.c',
-  'avatar_posix.c',
-  'remote_memory.c',
-  'irq_controller.c'
-))
-specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_I386'], if_true: files(
-  'configurable_machine.c',
-  'avatar_posix.c',
-  'remote_memory.c'
-))
-specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_PPC'], if_true: files(
-  'avatar_posix.c',
-  'remote_memory.c',
-  'irq_controller.c',
-))
-specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_X86_64'], if_true: files('configurable_machine.c'))
-specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_PPC'], if_true: files('configurable_machine.c'))
+  specific_ss.add(when: 'TARGET_MIPS', if_true: files(
+    'configurable_machine.c',
+    'avatar_posix.c',
+    'remote_memory.c',
+    'irq_controller.c'
+  ))
+  specific_ss.add(when: 'TARGET_I386', if_true: files(
+    'configurable_machine.c',
+    'avatar_posix.c',
+    'remote_memory.c'
+  ))
+  specific_ss.add(when: 'TARGET_PPC', if_true: files(
+    'configurable_machine.c',
+    'avatar_posix.c',
+    'remote_memory.c',
+    'irq_controller.c',
+  ))
+  specific_ss.add(when: 'TARGET_PPC64', if_true: files(
+    'configurable_machine.c',
+    'avatar_posix.c',
+    'remote_memory.c',
+    'irq_controller.c',
+  ))
+  specific_ss.add(when: 'TARGET_X86_64', if_true: files('configurable_machine.c'))
 
-specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_AVR'], if_true: files(
-  'configurable_machine.c',
-  'avatar_posix.c',
-  'remote_memory.c',
-))
+  specific_ss.add(when: 'TARGET_AVR', if_true: files(
+    'configurable_machine.c',
+    'avatar_posix.c',
+    'remote_memory.c',
+  ))
+endif

--- a/hw/core/machine.c
+++ b/hw/core/machine.c
@@ -802,6 +802,11 @@ static void machine_class_init(ObjectClass *oc, void *data)
     object_class_property_set_description(oc, "avatar-config",
         "Avatar Config File");
 
+    object_class_property_add_str(oc, "config-filename",
+        machine_get_avatar_config, machine_set_avatar_config);
+    object_class_property_set_description(oc, "config-filename",
+        "Avatar Config File (alias for avatar-config)");
+
     object_class_property_add_str(oc, "initrd",
         machine_get_initrd, machine_set_initrd);
     object_class_property_set_description(oc, "initrd",

--- a/target/ppc/cpu_init.c
+++ b/target/ppc/cpu_init.c
@@ -25,6 +25,7 @@
 #include "sysemu/cpus.h"
 #include "sysemu/hw_accel.h"
 #include "sysemu/tcg.h"
+#include "hw/boards.h"
 #include "cpu-models.h"
 #include "mmu-hash32.h"
 #include "mmu-hash64.h"
@@ -8813,7 +8814,10 @@ static void ppc_cpu_reset(DeviceState *dev)
     msr |= (target_ulong)MSR_HVB;
     msr |= (target_ulong)0 << MSR_AP; /* TO BE CHECKED */
     msr |= (target_ulong)0 << MSR_SA; /* TO BE CHECKED */
-    msr |= (target_ulong)1 << MSR_EP;
+    /* Don't set EP for configurable machine - exception vectors at 0x0 */
+    if (strcmp(MACHINE_GET_CLASS(current_machine)->name, "configurable") != 0) {
+        msr |= (target_ulong)1 << MSR_EP;
+    }
 #if defined(DO_SINGLE_STEP) && 0
     /* Single step trace mode */
     msr |= (target_ulong)1 << MSR_SE;
@@ -8850,7 +8854,10 @@ static void ppc_cpu_reset(DeviceState *dev)
 #if !defined(CONFIG_USER_ONLY)
     env->nip = env->hreset_vector | env->excp_prefix;
 #if defined(CONFIG_TCG)
-    if (env->mmu_model != POWERPC_MMU_REAL) {
+    /* Skip TLB invalidation for configurable machine — it sets up
+     * identity-mapped TLB entries that must persist through reset. */
+    if (env->mmu_model != POWERPC_MMU_REAL &&
+        strcmp(MACHINE_GET_CLASS(current_machine)->name, "configurable") != 0) {
         ppc_tlb_invalidate_all(env);
     }
 #endif /* CONFIG_TCG */

--- a/target/ppc/gdbstub.c
+++ b/target/ppc/gdbstub.c
@@ -162,7 +162,13 @@ int ppc_cpu_gdb_read_register(CPUState *cs, GByteArray *buf, int n)
             gdb_get_reg32(buf, cpu_read_xer(env));
             break;
         case 70:
-            gdb_get_reg32(buf, env->fpscr);
+            /* fpscr — target_ulong to match ppc_gdb_register_len() and
+             * the corresponding write path in ppc_cpu_gdb_write_register,
+             * which both use target_ulong sizes. Using gdb_get_reg32 here
+             * appended 4 bytes while the register-length helper claimed 8
+             * on ppc64, which tripped the g-packet length assertion in
+             * gdbstub.c's handle_read_all_regs. */
+            gdb_get_regl(buf, env->fpscr);
             break;
         }
     }


### PR DESCRIPTION
configurable_machine.c:
- Clear pending_interrupts, interrupt_request, and exception_index after CPU creation to prevent spurious "Invalid PowerPC exception 0"
- Clear MSR[EP] so exception vectors are at 0x0 (configurable machine has no memory at 0xFFF00000)
- Don't initialize timebase/decrementer (prevents unhandled timer interrupts without exception vector setup)
- Add hreg_compute_hflags() for correct cpu_mmu_index in real mode
- Add BookE TLB identity-mapped entries for e500 CPUs
- Register PPC CPU reset handler to re-apply all fixes after reset

cpu_init.c:
- Skip MSR[EP] for configurable machine
- Skip TLB invalidation during reset for configurable machine

meson.build:
- Use have_avatar flag instead of CONFIG_AVATAR in device config (avoids config poisoning errors)
- Add explicit TARGET_PPC64 entry for PPC64 builds