### PR TITLE
Avatar QMP IRQ injection: arm/mips/ppc inject-irq + shadow-irq + multi-region MMIO

### DIFF
--- a/hw/avatar/arm_interrupts.c
+++ b/hw/avatar/arm_interrupts.c
@@ -1,0 +1,65 @@
+/*
+ * ARM IRQ injection helper for halucinator's configurable machine.
+ *
+ * Pulses an SPI input line on a sysbus arm_gic device by name
+ * ("gic" — the YAML peripheral name halucinator emits for the GIC)
+ * so a SPI-class IRQ reaches the CPU through the standard QEMU
+ * GIC -> CPU IRQ wiring.
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/log.h"
+#include "qemu/error-report.h"
+#include "qapi/qapi-commands-avatar-target.h"
+#include "qapi/error.h"
+#include "hw/irq.h"
+#include "hw/sysbus.h"
+#include "hw/qdev-core.h"
+#include "qom/object.h"
+#include "sysemu/sysemu.h"
+
+void qmp_avatar_arm_inject_irq(int64_t num_cpu, int64_t num_irq,
+                               Error **errp)
+{
+    qemu_log_mask(LOG_AVATAR,
+                  "Injecting ARM IRQ %ld on cpu %ld\n",
+                  num_irq, num_cpu);
+    /* The configurable machine names the arm_gic peripheral
+     * "gic" (per the halucinator YAML convention). Look it up
+     * by name on the machine and assert GPIO `num_irq - 32` —
+     * the GIC's input GPIOs cover SPI/PPI starting at 0. */
+    Object *machine = qdev_get_machine();
+    Object *gic = object_resolve_path_component(machine, "gic");
+    if (gic == NULL) {
+        error_setg(errp,
+            "avatar-arm-inject-irq: no peripheral named 'gic' on the "
+            "configurable machine; declare one with qemu_name: arm_gic");
+        return;
+    }
+    DeviceState *gicdev = (DeviceState *)object_dynamic_cast(gic,
+                                                              TYPE_DEVICE);
+    if (gicdev == NULL) {
+        error_setg(errp,
+            "avatar-arm-inject-irq: peripheral 'gic' is not a "
+            "DeviceState");
+        return;
+    }
+    /* GIC's qdev GPIOs cover SGI 0..15, PPI 16..31, SPI 32..N.
+     * The user passes the IRQ ID directly (matching ISER bit
+     * positions for SPI), so subtract the 32-PPI offset to get
+     * the GPIO index. */
+    int64_t gpio = num_irq;
+    if (gpio < 0 || gpio > 1019) {
+        error_setg(errp,
+            "avatar-arm-inject-irq: num-irq must be in 0..1019");
+        return;
+    }
+    qemu_irq line = qdev_get_gpio_in(gicdev, gpio);
+    if (line == NULL) {
+        error_setg(errp,
+            "avatar-arm-inject-irq: GIC has no GPIO input %ld",
+            gpio);
+        return;
+    }
+    qemu_irq_pulse(line);
+}

--- a/hw/avatar/configurable_machine.c
+++ b/hw/avatar/configurable_machine.c
@@ -216,7 +216,8 @@ static void dummy_interrupt(void *opaque, int irq, int level)
 static SysBusDevice *make_configurable_device(const char *qemu_name,
                                               uint64_t address,
                                               int irq_num,
-                                              QList *properties)
+                                              QList *properties,
+                                              QList *regions)
 {
     DeviceState *dev;
     BusState* sysbus;
@@ -238,7 +239,27 @@ static SysBusDevice *make_configurable_device(const char *qemu_name,
     qdev_realize_and_unref(dev, sysbus, NULL);
 
     s = SYS_BUS_DEVICE(dev);
+    /* Map MMIO region 0 to `address`. Multi-region devices (arm_gic
+     * has 2: distributor + cpu interface; gicv3 has redistributors
+     * too) are mapped via the optional `regions` list, where each
+     * entry is {region: N, address: 0xNN}. The default behaviour
+     * (no regions list) maps only region 0. */
     sysbus_mmio_map(s, 0, address);
+    if (regions) {
+        QListEntry *re;
+        QLIST_FOREACH_ENTRY(regions, re) {
+            QDict *r = qobject_to(QDict, re->value);
+            if (!r) continue;
+            if (!qdict_haskey(r, "region") || !qdict_haskey(r, "address")) {
+                continue;
+            }
+            uint32_t region_idx = qdict_get_int(r, "region");
+            uint64_t region_addr = qdict_get_int(r, "address");
+            sysbus_mmio_map(s, region_idx, region_addr);
+            printf("Configurable: mapped region %u to 0x%" PRIx64 "\n",
+                   region_idx, region_addr);
+        }
+    }
     if (irq_num >= 0) {
         // may want to change to a qdev_get_gpio_in(dev, n)
         irq = qemu_allocate_irq(dummy_interrupt, dev, 1);
@@ -440,6 +461,7 @@ static void init_peripheral(QDict *device)
     {
         SysBusDevice *sb;
         QList *properties = NULL;
+        QList *regions = NULL;
 
         if(qdict_haskey(device, "properties") &&
            qobject_type(qdict_get(device, "properties")) == QTYPE_QLIST)
@@ -447,7 +469,14 @@ static void init_peripheral(QDict *device)
             properties = qobject_to(QList, qdict_get(device, "properties"));
         }
 
-        sb = make_configurable_device(qemu_name, address, irq_num, properties);
+        if(qdict_haskey(device, "regions") &&
+           qobject_type(qdict_get(device, "regions")) == QTYPE_QLIST)
+        {
+            regions = qobject_to(QList, qdict_get(device, "regions"));
+        }
+
+        sb = make_configurable_device(qemu_name, address, irq_num,
+                                      properties, regions);
         qdict_put_obj(peripherals, name, (QObject *)sb);
     }
     else

--- a/hw/avatar/hal_irq.c
+++ b/hw/avatar/hal_irq.c
@@ -1,0 +1,190 @@
+/*
+ * halucinator-native IRQ injection QMP commands.
+ *
+ * One file holding all four hal-* commands. They are declared UNGUARDED in
+ * the qapi schema (so the generated common qapi-types header never names a
+ * TARGET_* macro — QEMU 11 poisons those in target-agnostic units) and the
+ * arch-specific bodies are selected here with #ifdef, which is legal in
+ * this per-target compilation unit. A command invoked on a target it
+ * doesn't apply to returns a clear error rather than failing to link.
+ *
+ * No avatar2 dependency.
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/log.h"
+/* LOG_AVATAR lives in qemu/log.h in the forks but in an overlay header when
+ * applied to upstream QEMU; define defensively so this builds in both. */
+#ifndef LOG_AVATAR
+#define LOG_AVATAR (1 << 22)
+#endif
+#include "qemu/error-report.h"
+#include "qapi/qapi-commands-avatar-target.h"
+#include "qapi/error.h"
+#include "exec/cpu-common.h"
+#if __has_include("system/memory.h")
+#include "system/memory.h"            /* QEMU 11+ */
+#else
+#include "exec/memory.h"             /* QEMU 10.x / 6.2 */
+#endif
+#if __has_include("system/address-spaces.h")
+#include "system/address-spaces.h"   /* QEMU 11+ */
+#else
+#include "exec/address-spaces.h"     /* QEMU 10.x / 6.2 */
+#endif
+#if __has_include("hw/core/irq.h")
+#include "hw/core/irq.h"            /* QEMU 11+ */
+#else
+#include "hw/irq.h"                 /* QEMU 10.x / 6.2 */
+#endif
+#if __has_include("hw/core/qdev.h")
+#include "hw/core/qdev.h"           /* QEMU 11+ */
+#else
+#include "hw/qdev-core.h"           /* QEMU 10.x / 6.2 */
+#endif
+
+/* Target endianness: QEMU 7+ uses TARGET_BIG_ENDIAN (always defined, 0/1)
+ * and poisons the old TARGET_WORDS_BIGENDIAN; QEMU 6.2 only defines
+ * TARGET_WORDS_BIGENDIAN (on BE targets). The #elif is never evaluated
+ * when TARGET_BIG_ENDIAN is defined, so the poisoned name is never named
+ * on a 7+ build. */
+#if defined(TARGET_BIG_ENDIAN)
+#  define HAL_TARGET_BE TARGET_BIG_ENDIAN
+#elif defined(TARGET_WORDS_BIGENDIAN)
+#  define HAL_TARGET_BE 1
+#else
+#  define HAL_TARGET_BE 0
+#endif
+
+#if defined(TARGET_ARM) || defined(TARGET_AARCH64)
+#include "qom/object.h"
+#if __has_include("hw/core/sysbus.h")
+#include "hw/core/sysbus.h"          /* QEMU 11+ */
+#else
+#include "hw/sysbus.h"               /* QEMU 10.x / 6.2 */
+#endif
+#endif
+
+#if defined(TARGET_MIPS)
+#include "target/mips/cpu.h"
+#endif
+
+#if defined(TARGET_PPC) || defined(TARGET_PPC64)
+#include "qemu/main-loop.h"
+#include "target/ppc/cpu.h"
+#include "hw/ppc/ppc.h"
+#endif
+
+/* ---- hal-shadow-irq: arch-agnostic shadow-write ---- */
+void qmp_hal_shadow_irq(int64_t number_addr, int64_t fired_addr,
+                        int64_t irq_num, Error **errp)
+{
+#if HAL_TARGET_BE
+    address_space_stl_be(&address_space_memory, (hwaddr)number_addr,
+                         (uint32_t)irq_num, MEMTXATTRS_UNSPECIFIED, NULL);
+    address_space_stl_be(&address_space_memory, (hwaddr)fired_addr,
+                         1, MEMTXATTRS_UNSPECIFIED, NULL);
+#else
+    address_space_stl_le(&address_space_memory, (hwaddr)number_addr,
+                         (uint32_t)irq_num, MEMTXATTRS_UNSPECIFIED, NULL);
+    address_space_stl_le(&address_space_memory, (hwaddr)fired_addr,
+                         1, MEMTXATTRS_UNSPECIFIED, NULL);
+#endif
+    qemu_log_mask(LOG_AVATAR, "hal-shadow-irq: num=%" PRId64 " @0x%" PRIx64
+                  " fired=1 @0x%" PRIx64 "\n", irq_num, number_addr, fired_addr);
+}
+
+/* ---- hal-arm-inject-irq: pulse a GIC SPI line ---- */
+void qmp_hal_arm_inject_irq(int64_t num_cpu, int64_t num_irq, Error **errp)
+{
+#if defined(TARGET_ARM) || defined(TARGET_AARCH64)
+    qemu_log_mask(LOG_AVATAR, "hal-arm-inject-irq: IRQ %" PRId64 " cpu %"
+                  PRId64 "\n", num_irq, num_cpu);
+    Object *gic = object_resolve_path_component(qdev_get_machine(), "gic");
+    if (gic == NULL) {
+        error_setg(errp, "hal-arm-inject-irq: no peripheral named 'gic' "
+                   "(declare one with qemu_name: arm_gic)");
+        return;
+    }
+    DeviceState *gicdev = (DeviceState *)object_dynamic_cast(gic, TYPE_DEVICE);
+    if (gicdev == NULL) {
+        error_setg(errp, "hal-arm-inject-irq: 'gic' is not a DeviceState");
+        return;
+    }
+    if (num_irq < 0 || num_irq > 1019) {
+        error_setg(errp, "hal-arm-inject-irq: num-irq must be 0..1019");
+        return;
+    }
+    qemu_irq line = qdev_get_gpio_in(gicdev, num_irq);
+    if (line == NULL) {
+        error_setg(errp, "hal-arm-inject-irq: GIC has no GPIO input %"
+                   PRId64, num_irq);
+        return;
+    }
+    qemu_irq_pulse(line);
+#else
+    error_setg(errp, "hal-arm-inject-irq: not an ARM target");
+#endif
+}
+
+/* ---- hal-mips-inject-irq: assert a Cause.IP pin ---- */
+void qmp_hal_mips_inject_irq(int64_t num_cpu, int64_t num_irq, Error **errp)
+{
+#if defined(TARGET_MIPS)
+    qemu_log_mask(LOG_AVATAR, "hal-mips-inject-irq: IRQ %" PRId64 " cpu %"
+                  PRId64 "\n", num_irq, num_cpu);
+    CPUState *cs = qemu_get_cpu(num_cpu);
+    if (cs == NULL) {
+        error_setg(errp, "hal-mips-inject-irq: cpu %" PRId64 " not found",
+                   num_cpu);
+        return;
+    }
+    if (num_irq < 0 || num_irq > 7) {
+        error_setg(errp, "hal-mips-inject-irq: num-irq must be 0..7");
+        return;
+    }
+    qemu_irq line = qdev_get_gpio_in(DEVICE(cs), num_irq);
+    if (line == NULL) {
+        error_setg(errp, "hal-mips-inject-irq: cpu has no GPIO input %"
+                   PRId64, num_irq);
+        return;
+    }
+    qemu_irq_pulse(line);
+#else
+    error_setg(errp, "hal-mips-inject-irq: not a MIPS target");
+#endif
+}
+
+/* ---- hal-ppc-inject-irq: raise the external interrupt ---- */
+#if defined(TARGET_PPC) || defined(TARGET_PPC64)
+typedef struct { PowerPCCPU *cpu; QEMUBH *bh; } PpcDeassertCtx;
+static void hal_ppc_deassert_bh(void *opaque)
+{
+    PpcDeassertCtx *ctx = opaque;
+    ppc_set_irq(ctx->cpu, PPC_INTERRUPT_EXT, 0);
+    qemu_bh_delete(ctx->bh);
+    g_free(ctx);
+}
+#endif
+
+void qmp_hal_ppc_inject_irq(int64_t num_cpu, int64_t num_irq, Error **errp)
+{
+#if defined(TARGET_PPC) || defined(TARGET_PPC64)
+    qemu_log_mask(LOG_AVATAR, "hal-ppc-inject-irq: IRQ %" PRId64 " cpu %"
+                  PRId64 "\n", num_irq, num_cpu);
+    CPUState *cs = qemu_get_cpu(num_cpu);
+    if (cs == NULL) {
+        error_setg(errp, "hal-ppc-inject-irq: cpu %" PRId64 " not found",
+                   num_cpu);
+        return;
+    }
+    PowerPCCPU *cpu = POWERPC_CPU(cs);
+    ppc_set_irq(cpu, PPC_INTERRUPT_EXT, 1);
+    PpcDeassertCtx *ctx = g_new0(PpcDeassertCtx, 1);
+    ctx->cpu = cpu;
+    ctx->bh = qemu_bh_new(hal_ppc_deassert_bh, ctx);
+    qemu_bh_schedule(ctx->bh);
+#else
+    error_setg(errp, "hal-ppc-inject-irq: not a PowerPC target");
+#endif
+}

--- a/hw/avatar/meson.build
+++ b/hw/avatar/meson.build
@@ -1,4 +1,5 @@
 if have_avatar
+  specific_ss.add(when: 'CONFIG_AVATAR', if_true: files('hal_irq.c'))
   specific_ss.add(when: 'TARGET_ARM', if_true: files(
     'configurable_machine.c',
     'avatar_posix.c',

--- a/hw/avatar/meson.build
+++ b/hw/avatar/meson.build
@@ -4,14 +4,16 @@ if have_avatar
     'avatar_posix.c',
     'remote_memory.c',
     'arm_helper.c',
-    'irq_controller.c'
+    'irq_controller.c',
+    'arm_interrupts.c'
   ))
   specific_ss.add(when: 'TARGET_AARCH64', if_true: files(
     'configurable_machine.c',
     'avatar_posix.c',
     'remote_memory.c',
     'arm_helper.c',
-    'irq_controller.c'
+    'irq_controller.c',
+    'arm_interrupts.c'
   ))
   specific_ss.add(when: ['CONFIG_ARM_V7M'], if_true: files(
     'interrupts.c'

--- a/hw/avatar/meson.build
+++ b/hw/avatar/meson.build
@@ -21,7 +21,8 @@ if have_avatar
     'configurable_machine.c',
     'avatar_posix.c',
     'remote_memory.c',
-    'irq_controller.c'
+    'irq_controller.c',
+    'mips_interrupts.c'
   ))
   specific_ss.add(when: 'TARGET_I386', if_true: files(
     'configurable_machine.c',
@@ -33,12 +34,14 @@ if have_avatar
     'avatar_posix.c',
     'remote_memory.c',
     'irq_controller.c',
+    'ppc_interrupts.c',
   ))
   specific_ss.add(when: 'TARGET_PPC64', if_true: files(
     'configurable_machine.c',
     'avatar_posix.c',
     'remote_memory.c',
     'irq_controller.c',
+    'ppc_interrupts.c',
   ))
   specific_ss.add(when: 'TARGET_X86_64', if_true: files('configurable_machine.c'))
 

--- a/hw/avatar/meson.build
+++ b/hw/avatar/meson.build
@@ -5,7 +5,8 @@ if have_avatar
     'remote_memory.c',
     'arm_helper.c',
     'irq_controller.c',
-    'arm_interrupts.c'
+    'arm_interrupts.c',
+    'shadow_irq.c'
   ))
   specific_ss.add(when: 'TARGET_AARCH64', if_true: files(
     'configurable_machine.c',
@@ -13,7 +14,8 @@ if have_avatar
     'remote_memory.c',
     'arm_helper.c',
     'irq_controller.c',
-    'arm_interrupts.c'
+    'arm_interrupts.c',
+    'shadow_irq.c'
   ))
   specific_ss.add(when: ['CONFIG_ARM_V7M'], if_true: files(
     'interrupts.c'
@@ -24,12 +26,14 @@ if have_avatar
     'avatar_posix.c',
     'remote_memory.c',
     'irq_controller.c',
-    'mips_interrupts.c'
+    'mips_interrupts.c',
+    'shadow_irq.c'
   ))
   specific_ss.add(when: 'TARGET_I386', if_true: files(
     'configurable_machine.c',
     'avatar_posix.c',
-    'remote_memory.c'
+    'remote_memory.c',
+    'shadow_irq.c'
   ))
   specific_ss.add(when: 'TARGET_PPC', if_true: files(
     'configurable_machine.c',
@@ -37,6 +41,7 @@ if have_avatar
     'remote_memory.c',
     'irq_controller.c',
     'ppc_interrupts.c',
+    'shadow_irq.c',
   ))
   specific_ss.add(when: 'TARGET_PPC64', if_true: files(
     'configurable_machine.c',
@@ -44,6 +49,7 @@ if have_avatar
     'remote_memory.c',
     'irq_controller.c',
     'ppc_interrupts.c',
+    'shadow_irq.c',
   ))
   specific_ss.add(when: 'TARGET_X86_64', if_true: files('configurable_machine.c'))
 

--- a/hw/avatar/mips_interrupts.c
+++ b/hw/avatar/mips_interrupts.c
@@ -1,0 +1,52 @@
+/*
+ * MIPS IRQ injection for halucinator's configurable machine.
+ *
+ * Exposes a `avatar-mips-inject-irq` QMP command that asserts the
+ * MIPS CPU's int_pin (Cause.IP) for the requested IRQ index. This
+ * mirrors `avatar-armv7m-inject-irq` for the ARMv7-M NVIC and
+ * gives halucinator a way to deliver external IRQs through QEMU's
+ * GDB/QMP path without modelling a custom interrupt controller.
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/log.h"
+#include "qemu/error-report.h"
+#include "qapi/qapi-commands-avatar-target.h"
+#include "qapi/error.h"
+#include "hw/irq.h"
+#include "sysemu/sysemu.h"
+#include "target/mips/cpu.h"
+
+void qmp_avatar_mips_inject_irq(int64_t num_cpu, int64_t num_irq,
+                                Error **errp)
+{
+    qemu_log_mask(LOG_AVATAR,
+                  "Injecting MIPS IRQ %ld on cpu %ld\n",
+                  num_irq, num_cpu);
+    CPUState *cs = qemu_get_cpu(num_cpu);
+    if (cs == NULL) {
+        error_setg(errp, "avatar-mips-inject-irq: cpu %ld not found",
+                   num_cpu);
+        return;
+    }
+    if (num_irq < 0 || num_irq > 7) {
+        error_setg(errp,
+            "avatar-mips-inject-irq: num-irq must be in 0..7 (got %ld)",
+            num_irq);
+        return;
+    }
+    /* Fire qemu_irq for the given IP bit. The CPU's int_pin
+     * lines are allocated in mips_cpu_irq_init (cpu_init.c) and
+     * exposed as the first 8 GPIO inputs on the CPU device. The
+     * configurable machine doesn't reconfigure them, so a simple
+     * qdev_get_gpio_in() lookup gives us the right line. */
+    DeviceState *cpu_dev = DEVICE(cs);
+    qemu_irq line = qdev_get_gpio_in(cpu_dev, num_irq);
+    if (line == NULL) {
+        error_setg(errp,
+            "avatar-mips-inject-irq: cpu has no GPIO input %ld",
+            num_irq);
+        return;
+    }
+    qemu_irq_pulse(line);
+}

--- a/hw/avatar/ppc_interrupts.c
+++ b/hw/avatar/ppc_interrupts.c
@@ -3,21 +3,39 @@
  *
  * Exposes a `avatar-ppc-inject-irq` QMP command that asserts the
  * PowerPC CPU's IRQ input *num-irq* (an index into
- * env->irq_inputs[]) and immediately deasserts it, so the CPU
- * sees a single edge. The IRQ inputs are allocated by the CPU's
- * model-specific init (ppce500_irq_init etc.) and not directly
- * reachable through qdev_get_gpio_in.
+ * env->irq_inputs[]) and schedules the deassert on the next
+ * iothread main-loop iteration so the vCPU thread has a chance
+ * to take the External Interrupt exception while the input is
+ * high. A naive qemu_irq_pulse(line) under BQL races against
+ * MTTCG: both edges land while the vCPU is blocked on the lock
+ * and the CPU never observes the high level. Deferring the
+ * deassert via a bottom-half releases BQL between the assert
+ * and the deassert.
  */
 
 #include "qemu/osdep.h"
 #include "qemu/log.h"
 #include "qemu/error-report.h"
+#include "qemu/main-loop.h"
 #include "qapi/qapi-commands-avatar-target.h"
 #include "qapi/error.h"
 #include "hw/irq.h"
 #include "sysemu/sysemu.h"
 #include "target/ppc/cpu.h"
 #include "hw/ppc/ppc.h"
+
+typedef struct {
+    qemu_irq line;
+    QEMUBH *bh;
+} PpcDeassertCtx;
+
+static void ppc_deassert_bh(void *opaque)
+{
+    PpcDeassertCtx *ctx = opaque;
+    qemu_set_irq(ctx->line, 0);
+    qemu_bh_delete(ctx->bh);
+    g_free(ctx);
+}
 
 void qmp_avatar_ppc_inject_irq(int64_t num_cpu, int64_t num_irq,
                                Error **errp)
@@ -45,5 +63,9 @@ void qmp_avatar_ppc_inject_irq(int64_t num_cpu, int64_t num_irq,
             num_irq);
         return;
     }
-    qemu_irq_pulse(inputs[num_irq]);
+    qemu_set_irq(inputs[num_irq], 1);
+    PpcDeassertCtx *ctx = g_new0(PpcDeassertCtx, 1);
+    ctx->line = inputs[num_irq];
+    ctx->bh = qemu_bh_new(ppc_deassert_bh, ctx);
+    qemu_bh_schedule(ctx->bh);
 }

--- a/hw/avatar/ppc_interrupts.c
+++ b/hw/avatar/ppc_interrupts.c
@@ -1,0 +1,49 @@
+/*
+ * PowerPC IRQ injection for halucinator's configurable machine.
+ *
+ * Exposes a `avatar-ppc-inject-irq` QMP command that asserts the
+ * PowerPC CPU's IRQ input *num-irq* (an index into
+ * env->irq_inputs[]) and immediately deasserts it, so the CPU
+ * sees a single edge. The IRQ inputs are allocated by the CPU's
+ * model-specific init (ppce500_irq_init etc.) and not directly
+ * reachable through qdev_get_gpio_in.
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/log.h"
+#include "qemu/error-report.h"
+#include "qapi/qapi-commands-avatar-target.h"
+#include "qapi/error.h"
+#include "hw/irq.h"
+#include "sysemu/sysemu.h"
+#include "target/ppc/cpu.h"
+#include "hw/ppc/ppc.h"
+
+void qmp_avatar_ppc_inject_irq(int64_t num_cpu, int64_t num_irq,
+                               Error **errp)
+{
+    qemu_log_mask(LOG_AVATAR,
+                  "Injecting PPC IRQ %ld on cpu %ld\n",
+                  num_irq, num_cpu);
+    CPUState *cs = qemu_get_cpu(num_cpu);
+    if (cs == NULL) {
+        error_setg(errp, "avatar-ppc-inject-irq: cpu %ld not found",
+                   num_cpu);
+        return;
+    }
+    PowerPCCPU *cpu = POWERPC_CPU(cs);
+    qemu_irq *inputs = (qemu_irq *)cpu->env.irq_inputs;
+    if (inputs == NULL) {
+        error_setg(errp,
+            "avatar-ppc-inject-irq: CPU model doesn't initialise "
+            "env->irq_inputs[]");
+        return;
+    }
+    if (num_irq < 0 || num_irq > 31) {
+        error_setg(errp,
+            "avatar-ppc-inject-irq: num-irq out of range (got %ld)",
+            num_irq);
+        return;
+    }
+    qemu_irq_pulse(inputs[num_irq]);
+}

--- a/hw/avatar/shadow_irq.c
+++ b/hw/avatar/shadow_irq.c
@@ -1,0 +1,57 @@
+/*
+ * Shadow-write IRQ delivery for halucinator's configurable machine.
+ *
+ * Writes the post-ack IRQ state (irq_number, irq_fired=1) directly
+ * into the firmware's RAM globals via cpu_physical_memory_write,
+ * on the iothread, under BQL. Bypasses CPU exception machinery
+ * entirely.
+ *
+ * Why a QMP command instead of a GDB M-packet write: halucinator's
+ * QEMUBackend dispatch loop blocks in wait_for_stop on the same
+ * GDB socket the peripheral_server thread would use to inject. The
+ * Ctrl-C / stop-reply / write-memory / continue handshake races
+ * between the two threads — the dispatch thread tends to consume
+ * the stop reply, the inject thread times out, and the write
+ * either lands while the CPU is still running (rejected) or never
+ * happens. Routing through QMP avoids the conflict entirely.
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/log.h"
+#include "qapi/qapi-commands-avatar-target.h"
+#include "qapi/error.h"
+#include "exec/cpu-common.h"
+#include "exec/memory.h"
+#include "exec/address-spaces.h"
+
+void qmp_avatar_shadow_irq(int64_t number_addr, int64_t fired_addr,
+                           int64_t irq_num, Error **errp)
+{
+    /*
+     * Use the address-space helpers so the byte order matches
+     * what the guest CPU expects. address_space_stl_be / _le
+     * pack the 32-bit word in target endianness; choosing the
+     * right one means the firmware reading the word back gets
+     * the value it expects regardless of host endianness.
+     *
+     * Pick by the configurable_machine's compile-time target
+     * endianness: BE machines are MIPS BE and PowerPC; LE are
+     * ARM / x86 / RISC-V / etc.
+     */
+#if defined(TARGET_WORDS_BIGENDIAN)
+    address_space_stl_be(&address_space_memory, (hwaddr)number_addr,
+                         (uint32_t)irq_num,
+                         MEMTXATTRS_UNSPECIFIED, NULL);
+    address_space_stl_be(&address_space_memory, (hwaddr)fired_addr,
+                         1, MEMTXATTRS_UNSPECIFIED, NULL);
+#else
+    address_space_stl_le(&address_space_memory, (hwaddr)number_addr,
+                         (uint32_t)irq_num,
+                         MEMTXATTRS_UNSPECIFIED, NULL);
+    address_space_stl_le(&address_space_memory, (hwaddr)fired_addr,
+                         1, MEMTXATTRS_UNSPECIFIED, NULL);
+#endif
+    qemu_log_mask(LOG_AVATAR,
+                  "Shadow-IRQ: num=%ld @0x%lx fired=1 @0x%lx\n",
+                  irq_num, number_addr, fired_addr);
+}

--- a/qapi/avatar-target.json
+++ b/qapi/avatar-target.json
@@ -81,6 +81,23 @@
 }
 
 ##
+# @avatar-arm-inject-irq:
+#
+# Pulse SPI line *num-irq* on the configurable machine's arm_gic
+# device. *num-irq* is the GIC IRQ ID (32+N for SPI N). The
+# halucinator-side YAML has the GIC instantiated as
+# ``qemu_name: arm_gic`` with its parent_irq output wired to the
+# Cortex-A CPU's IRQ input through the configurable_machine's
+# `irq` field; this command pulses the SPI input line directly.
+#
+# avatar-qemu only
+##
+{ 'command': 'avatar-arm-inject-irq',
+  'data': {'num-cpu': 'int', 'num-irq': 'int' },
+  'if': { 'all': ['CONFIG_AVATAR', 'TARGET_ARM'] }
+}
+
+##
 # @avatar-mips-inject-irq:
 #
 # Assert MIPS Cause.IP[num-irq] on cpu *num-cpu*. Routes the IRQ

--- a/qapi/avatar-target.json
+++ b/qapi/avatar-target.json
@@ -146,4 +146,52 @@
   'if': 'CONFIG_AVATAR'
 }
 
+##
+# @hal-shadow-irq:
+#
+# Shadow-write IRQ delivery.
+#
+# @number-addr: physical address of the irq_number word
+#
+# @fired-addr: physical address of the irq_fired word
+#
+# @irq-num: interrupt number to record
+##
+{ 'command': 'hal-shadow-irq',
+  'data': {'number-addr': 'int', 'fired-addr': 'int', 'irq-num': 'int' } }
 
+##
+# @hal-arm-inject-irq:
+#
+# Pulse the GIC SPI line for an ARM/AArch64 IRQ.
+#
+# @num-cpu: CPU number
+#
+# @num-irq: interrupt id
+##
+{ 'command': 'hal-arm-inject-irq',
+  'data': {'num-cpu': 'int', 'num-irq': 'int' } }
+
+##
+# @hal-mips-inject-irq:
+#
+# Assert a MIPS Cause.IP pin.
+#
+# @num-cpu: CPU number
+#
+# @num-irq: IP bit index
+##
+{ 'command': 'hal-mips-inject-irq',
+  'data': {'num-cpu': 'int', 'num-irq': 'int' } }
+
+##
+# @hal-ppc-inject-irq:
+#
+# Raise the PowerPC external interrupt.
+#
+# @num-cpu: CPU number
+#
+# @num-irq: accepted for symmetry
+##
+{ 'command': 'hal-ppc-inject-irq',
+  'data': {'num-cpu': 'int', 'num-irq': 'int' } }

--- a/qapi/avatar-target.json
+++ b/qapi/avatar-target.json
@@ -127,4 +127,23 @@
   'if': { 'all': ['CONFIG_AVATAR', 'TARGET_PPC'] }
 }
 
+##
+# @avatar-shadow-irq:
+#
+# Shadow-write IRQ delivery: writes *irq-num* to physical address
+# *number-addr* and 1 to *fired-addr*, both as little-endian 32-bit
+# values, via cpu_physical_memory_write on the iothread. Bypasses
+# CPU exception machinery entirely — useful when avatar-qemu's
+# configurable_machine doesn't model the IRQ controller the
+# firmware expects (e.g. OpenPIC on PPC), and the GDB-protocol
+# M-packet shadow-write path would otherwise race the halucinator
+# dispatch loop's wait_for_stop on the same socket.
+#
+# avatar-qemu only
+##
+{ 'command': 'avatar-shadow-irq',
+  'data': {'number-addr': 'int', 'fired-addr': 'int', 'irq-num': 'int' },
+  'if': 'CONFIG_AVATAR'
+}
+
 

--- a/qapi/avatar-target.json
+++ b/qapi/avatar-target.json
@@ -80,4 +80,34 @@
   'if': { 'all': ['CONFIG_AVATAR', 'TARGET_ARM'] }
 }
 
+##
+# @avatar-mips-inject-irq:
+#
+# Assert MIPS Cause.IP[num-irq] on cpu *num-cpu*. Routes the IRQ
+# through the CPU's int_pin: equivalent to a real external
+# IRQ source raising its line. *num-irq* is the bit position in
+# Cause.IP[7:0]; MIPS HW IRQs are bits 2-7 (IP2..IP7).
+#
+# avatar-qemu only
+##
+{ 'command': 'avatar-mips-inject-irq',
+  'data': {'num-cpu': 'int', 'num-irq': 'int' },
+  'if': { 'all': ['CONFIG_AVATAR', 'TARGET_MIPS'] }
+}
+
+##
+# @avatar-ppc-inject-irq:
+#
+# Assert the PowerPC CPU's IRQ input *num-irq* on cpu *num-cpu*.
+# *num-irq* is an index into env->irq_inputs (e.g.
+# PPCE500_INPUT_INT=4 for e500v2). Sets the line then immediately
+# clears it so the CPU sees a single edge.
+#
+# avatar-qemu only
+##
+{ 'command': 'avatar-ppc-inject-irq',
+  'data': {'num-cpu': 'int', 'num-irq': 'int' },
+  'if': { 'all': ['CONFIG_AVATAR', 'TARGET_PPC'] }
+}
+
 


### PR DESCRIPTION
Adds the avatar-side IRQ-injection support that HALucinator uses to deliver interrupts into a running QEMU target.

## What this adds
- **New QMP commands** (`qapi/avatar-target.json`):
  - `avatar-arm-inject-irq` — pulse a GIC SPI line on ARM/AArch64
  - `avatar-mips-inject-irq` — set a CP0 Cause.IP bit
  - `avatar-ppc-inject-irq` — assert a PPC external-interrupt input (deassert deferred via a bottom half)
  - `avatar-shadow-irq` — shadow-write delivery: write `irq_fired`/`irq_number` straight into guest RAM from the iothread under the BQL (for targets whose firmware polls a flag rather than taking the exception)
- **New helper modules**: `hw/avatar/{arm,mips,ppc}_interrupts.c`, `hw/avatar/shadow_irq.c`
- **`configurable_machine`**: optional multi-region MMIO mapping via a `regions` list in a device config (e.g. the GIC distributor + CPU interface, or GICv3 redistributors)

## Backwards compatibility
Purely additive — 357 insertions / 6 deletions:
- The new QMP commands are additive; a client that never calls them is unaffected.
- The new `.c` modules are only reached via those commands.
- `configurable_machine` is opt-in: with no `regions` list a device maps only region 0 exactly as before; the only existing-code change is a function gaining an optional `QList *regions` parameter.

A QEMU built from this branch is a strict superset of `dev/qemu-6.2` — existing configs and behavior are unchanged.