### PR TITLE
avatar: i386 configurable-machine interrupt support (flat protected mode + LAPIC injection)

### DIFF
--- a/hw/avatar/configurable_machine.c
+++ b/hw/avatar/configurable_machine.c
@@ -599,6 +599,19 @@ static THISCPU *create_cpu(MachineState * ms, QDict *conf)
 #endif  /* ! TARGET_AARCH64 */
 
 #elif defined(TARGET_I386)
+    /* Select flat 32/64-bit mode BEFORE the CPU is realized. The X86CPU
+     * reset (triggered by qdev_realize below) reads
+     * x86_configurable_machine_mode to install flat segments; setting it
+     * only afterwards left the CPU in its real-mode reset state
+     * (CS base 0xffff0000), so execution at the configured entry address
+     * fetched from the wrong linear address and never ran the firmware. */
+    set_x86_configurable_machine(
+#if defined(TARGET_X86_64)
+        64
+#else
+        32
+#endif
+    );
     cpu_oc = cpu_class_by_name(TYPE_X86_CPU, cpu_type);
     if (!cpu_oc) {
         error_printf("Unable to find CPU definition\n");

--- a/hw/avatar/hal_irq.c
+++ b/hw/avatar/hal_irq.c
@@ -75,6 +75,10 @@
 #include "hw/ppc/ppc.h"
 #endif
 
+#if defined(TARGET_I386)
+#include "hw/i386/apic.h"
+#endif
+
 /* ---- hal-shadow-irq: arch-agnostic shadow-write ---- */
 void qmp_hal_shadow_irq(int64_t number_addr, int64_t fired_addr,
                         int64_t irq_num, Error **errp)
@@ -186,5 +190,26 @@ void qmp_hal_ppc_inject_irq(int64_t num_cpu, int64_t num_irq, Error **errp)
     qemu_bh_schedule(ctx->bh);
 #else
     error_setg(errp, "hal-ppc-inject-irq: not a PowerPC target");
+#endif
+}
+
+/* ---- hal-x86-inject-irq: deliver a fixed vector via the local APIC ---- */
+void qmp_hal_x86_inject_irq(int64_t num_cpu, int64_t num_irq, Error **errp)
+{
+#if defined(TARGET_I386)
+    qemu_log_mask(LOG_AVATAR, "hal-x86-inject-irq: vector %" PRId64 " cpu %"
+                  PRId64 "\n", num_irq, num_cpu);
+    if (num_irq < 0 || num_irq > 255) {
+        error_setg(errp, "hal-x86-inject-irq: vector must be 0..255");
+        return;
+    }
+    /* Deliver num_irq as a fixed-mode interrupt vector to the local APIC
+     * of CPU num_cpu (physical destination, edge-triggered). The firmware
+     * must have enabled its LAPIC and installed an IDT entry for the
+     * vector. APIC_DM_FIXED == 0 (apic_internal.h). */
+    apic_deliver_irq((uint8_t)num_cpu, 0 /* phys dest */, 0 /* APIC_DM_FIXED */,
+                     (uint8_t)num_irq, 0 /* edge */);
+#else
+    error_setg(errp, "hal-x86-inject-irq: not an x86 target");
 #endif
 }

--- a/hw/avatar/irq_controller.c
+++ b/hw/avatar/irq_controller.c
@@ -25,6 +25,9 @@
 #elif defined(TARGET_PPC)
 #  include "target/ppc/cpu.h"
 #  include "hw/avatar/halucinator_irq_memory.h"
+#elif defined(TARGET_I386)
+#  include "target/i386/cpu.h"
+#  include "hw/avatar/halucinator_irq_memory.h"
 #else
 # error "halucinator_irq: unsupported architecture"
 #endif

--- a/hw/avatar/remote_memory.c
+++ b/hw/avatar/remote_memory.c
@@ -20,6 +20,8 @@
 #  include "target/mips/cpu.h"
 #elif defined(TARGET_PPC)
 #  include "target/ppc/cpu.h"
+#elif defined(TARGET_I386)
+#  include "target/i386/cpu.h"
 #else
 #  error "avatar-rmemory: unsupported architecture"
 #endif
@@ -45,6 +47,10 @@ uint64_t get_current_pc(void)
 #elif defined(TARGET_PPC)
     PowerPCCPU *cpu = POWERPC_CPU(qemu_get_cpu(0));
     return cpu->env.nip;
+
+#elif defined(TARGET_I386)
+    X86CPU *cpu = X86_CPU(qemu_get_cpu(0));
+    return cpu->env.eip;
 
 #else
     error_report("avatar-rmemory: get_current_pc unsupported architecture\n");

--- a/qapi/avatar-target.json
+++ b/qapi/avatar-target.json
@@ -195,3 +195,17 @@
 ##
 { 'command': 'hal-ppc-inject-irq',
   'data': {'num-cpu': 'int', 'num-irq': 'int' } }
+
+##
+# @hal-x86-inject-irq:
+#
+# Deliver a fixed interrupt vector to the local APIC of an x86/i386 CPU.
+# The firmware must have enabled its LAPIC and installed an IDT entry for
+# the vector.
+#
+# @num-cpu: CPU number (APIC id)
+#
+# @num-irq: interrupt vector (0..255), delivered via APIC_DM_FIXED
+##
+{ 'command': 'hal-x86-inject-irq',
+  'data': {'num-cpu': 'int', 'num-irq': 'int' } }

--- a/target/i386/cpu.c
+++ b/target/i386/cpu.c
@@ -5839,28 +5839,33 @@ static void x86_cpu_reset(DeviceState *dev)
     unsigned int cs_selector = 0xf000;
     target_ulong cs_base = 0xffff0000;
 
+    target_ulong cm_limit = 0xffff;
     if (x86_configurable_machine_mode != 0) {
-      // For x86 configurable machine, we don't want to start in real mode
+      // For x86 configurable machine, we don't want to start in real mode;
+      // run flat with 4 GiB segment limits ("unicorn-style") so firmware can
+      // execute anywhere and reach high MMIO (e.g. the LAPIC at 0xFEE00000)
+      // without installing its own GDT.
       cs_selector = 0;
       cs_base = 0;
+      cm_limit = 0xffffffff;
     }
 
-    cpu_x86_load_seg_cache(env, R_CS, cs_selector, cs_base, 0xffff,
+    cpu_x86_load_seg_cache(env, R_CS, cs_selector, cs_base, cm_limit,
                            DESC_P_MASK | DESC_S_MASK | DESC_CS_MASK |
                            DESC_R_MASK | DESC_A_MASK);
-    cpu_x86_load_seg_cache(env, R_DS, 0, 0, 0xffff,
+    cpu_x86_load_seg_cache(env, R_DS, 0, 0, cm_limit,
                            DESC_P_MASK | DESC_S_MASK | DESC_W_MASK |
                            DESC_A_MASK);
-    cpu_x86_load_seg_cache(env, R_ES, 0, 0, 0xffff,
+    cpu_x86_load_seg_cache(env, R_ES, 0, 0, cm_limit,
                            DESC_P_MASK | DESC_S_MASK | DESC_W_MASK |
                            DESC_A_MASK);
-    cpu_x86_load_seg_cache(env, R_SS, 0, 0, 0xffff,
+    cpu_x86_load_seg_cache(env, R_SS, 0, 0, cm_limit,
                            DESC_P_MASK | DESC_S_MASK | DESC_W_MASK |
                            DESC_A_MASK);
-    cpu_x86_load_seg_cache(env, R_FS, 0, 0, 0xffff,
+    cpu_x86_load_seg_cache(env, R_FS, 0, 0, cm_limit,
                            DESC_P_MASK | DESC_S_MASK | DESC_W_MASK |
                            DESC_A_MASK);
-    cpu_x86_load_seg_cache(env, R_GS, 0, 0, 0xffff,
+    cpu_x86_load_seg_cache(env, R_GS, 0, 0, cm_limit,
                            DESC_P_MASK | DESC_S_MASK | DESC_W_MASK |
                            DESC_A_MASK);
 
@@ -5869,6 +5874,14 @@ static void x86_cpu_reset(DeviceState *dev)
       // setting up initial state. These registers
       // values should all be 0 or undefined at the start
       // of a unicorn-style execution
+
+      // Enter 32-bit protected mode (flat, no paging). The firmware relies
+      // on protected-mode semantics: a GDT far jump (ljmp $0x08) and
+      // IDT-based interrupt delivery. With CR0.PE=0 the far jump is treated
+      // as a real-mode segment load (CS base = sel<<4) and execution
+      // derails, and injected vectors dispatch through the real-mode IVT
+      // instead of the firmware's IDT.
+      cpu_x86_update_cr0(env, env->cr[0] | CR0_PE_MASK);
 
       // But do set hflags so we're in 32-bit mode (else we end up in 16-bit)
       env->hflags |= HF_CS32_MASK | HF_SS32_MASK;


### PR DESCRIPTION
Adds full i386/x86 interrupt-delivery support to the avatar configurable machine, so i386 firmware can be rehosted **and receive injected interrupts**. Base: `dev/qemu-6.2`.

## Commits
- **`avatar: i386 support for remote_memory + irq_controller`** — adds the `TARGET_I386` cases (`cpu.h` include, `get_current_pc -> env.eip`) so `i386-softmmu` builds; previously failed with `#error "avatar-rmemory: unsupported architecture"`.
- **`avatar: hal-x86-inject-irq QMP command`** — delivers a fixed interrupt vector to a CPU's local APIC via `apic_deliver_irq` (physical dest, edge, `APIC_DM_FIXED`). The firmware enables its LAPIC and installs an IDT entry for the vector.
- **`i386: flat 32-bit protected mode for the configurable machine`** — the configurable machine now starts the CPU in flat 32-bit protected mode instead of the real-mode reset state:
  - 4 GiB segment limits, so firmware can load high and reach MMIO such as the LAPIC at `0xFEE00000`;
  - the 32/64-bit mode is selected **before** the CPU is realized, so the realize-time reset applies it (otherwise the entry address fetched from the wrong linear address and the firmware never ran);
  - `CR0.PE=1` — without it a firmware GDT far jump (`ljmp $0x08`) is treated as a real-mode segment load (`CS base = sel<<4`) and execution derails, and injected vectors dispatch through the real-mode IVT instead of the firmware's IDT.

## Result
An i386 firmware can install its own GDT/IDT, enable the LAPIC, and receive injected fixed-vector interrupts end to end.

## Validation
Exercised by halucinator's i386 e2e IRQ tests (halucinator/halucinator#30), which build `qemu-system-i386` from this branch and inject via `hal-x86-inject-irq` — green on ubuntu-22.04 and 24.04. (This repo's only workflow is the QEMU `lockdown.yml` mirror bot, a fork no-op.)

Needed by halucinator/halucinator#30.
